### PR TITLE
redirecting to notebook; removing detailed steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,69 +20,7 @@ Please note - In order to run Notebooks on CUAHSI JupyterHub, the user's account
 1. Login to HydroShare or create a new account.
 2. Navigate to the HydroShare resource named MyAnalysis either through the search feature or using this direct link [here](https://www.hydroshare.org/resource/7d1403636fd3444c87e3c5b40b000b91/).
 3. Click the "Open with..." button from the resource's landing page in HydroShare
-4. Select CUAHSI JupyterHub. An instance will be opened on JupyterHub under the user account, where the user can reproduce and replicate the workflow analysis saved as a sciunit package using the following steps. 
- 
-Note: The user must issue sciunit shell commands by using the "!" expression in Jupyter. 
-
-5. Open the MyAnalysis sciunit container.
-
-```
-!sciunit open MyAnalysis
-````
-
-6. List all computational experiments within the MyAnalysis sciunit container.
-    
-```
-!sciunit list
-```
-
-7. Repeat the analysis.
-    
-    The command below will run the experiment 1 (e1) analysis on the Jupyter server. This e1 analysis is the hydrologic modeling workflow described in the Essawy at al. manuscript. 
-    
-```
-!sciunit repeat e1
-```
-
-8. Navigate to the reproduced output in the sciunit package. 
-
-   Once the experiment completes from the prior step, it will create a new directory on JupyterHub that includes software, data, and environment settings for the analysis run. You can navigate to this directory using the following command. 
-
-```
-!ls "/home/jovyan/work/sciunit/MyAnalysis/cde-package/cde-root/media/sf_pysumma/sciunit/"
-```
-
-9. Change SUMMA configurations from Ball-berry to Jarvis method to analyze the impact of total ET. 
-
-   The prior step illustrated reproducing a past model run. To take a step further and replicate the study by changing the workflow and running the new analysis, it is possible to edit the Notebook within the MyAnalysis container to reconfigure the pySUMMA model run.
-
-```
-with open(simulation_object, "r") as f:
-    read_data = f.read()
-    line = read_data.replace('BallBerry', "Jarvis")
-    f.close()
-with open(simulation_object, "w") as f:
-    f.write(line)
-    f.close()
-```
-
-10. Commit sciunit to replicate the sciunit container.
-
-    Once the change has been made to the Notebook file, it can be committed to the sciunit container as a new experiment. 
-   
-```
-!sciunit commit
-```
-
-11. Repeat the newly created the sciunit experiment.
-
-    The prior command creates a new experiment in the Sciunit container (e2) that can be run using the repeat command, just as we did before for e1 in step 7.
-
-```
-!sciunit repeat e2
-```
-
-These basic steps allow one to rerun a computational experiment created by others and change that experiment to something new. The new experiment is also stored in the sciunit container, allowing it to be easily shared and rerun by others. 
+4. Select CUAHSI JupyterHub. An instance will be opened on JupyterHub under the user account, where the user can reproduce and replicate the workflow analysis saved as a sciunit package by executing the MyAnalysis.ipynb notebook.
 
 Questions or problems executing these steps should be directed to Jon Goodall (goodall@virginia.edu). 
 


### PR DESCRIPTION
 It's kinda weird to follow the readme or the notebook. And some things in the readme don't really make sense without the notebook for context anyway. For example, in Step 9, what is "simulation_object"? I see in the notebook that it is the path to a simulation file, but in the readme that isn't defined. I guess another way of thinking about it is that the readme should be able to be totally self-describing. The notebook already has a lot of the info that is in the readme, so I think I would just merge whatever language you want to keep from the readme into the notebook. I made a PR for the Readme to show what I mean. This is just taking things out of the readme. You'd also have to go back and transfer any of that content that you want to the notebook (but most of it is there)